### PR TITLE
Re-export TypeScript types, add 'js-cookie' re-export for us-web-util v1.1.0

### DIFF
--- a/packages/us-web-util/CHANGELOG.md
+++ b/packages/us-web-util/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.1.0
+
+- Export `js-cookie` library as 'blessed' solution.
+- Re-export TypeScript typings for re-exported utilities.
+
 # 1.0.1
 
 - Fix issue with `package.json`

--- a/packages/us-web-util/lib/dom.ts
+++ b/packages/us-web-util/lib/dom.ts
@@ -1,3 +1,5 @@
+import Cookies from 'js-cookie'
+
 import { LngLat } from './types'
 
 const MAXIMUM_AGE_MINUTES = 30
@@ -101,3 +103,5 @@ export function isMobileSafari(): boolean {
 
     return isIOS && !isChromeIOS
 }
+
+export { Cookies }

--- a/packages/us-web-util/package.json
+++ b/packages/us-web-util/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dji-dev/us-web-util",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "main": "dist/index.js",
     "license": "All rights reserved.",
     "module": "./dist/index.js",
@@ -17,8 +17,13 @@
         "Haixiang Yan"
     ],
     "dependencies": {
+        "@types/clone-deep": "^4.0.1",
+        "@types/js-cookie": "^2.2.6",
+        "@types/lodash.debounce": "^4.0.6",
+        "@types/lodash.throttle": "^4.1.6",
         "clone-deep": "^4.0.1",
         "deepmerge": "^4.2.2",
+        "js-cookie": "^2.2.1",
         "lodash.debounce": "^4.0.8",
         "lodash.throttle": "^4.1.1"
     },
@@ -26,10 +31,7 @@
         "@babel/core": "^7.11.6",
         "@dji-dev/us-web-config": "1.0.0",
         "@rollup/plugin-typescript": "^5.0.1",
-        "@types/clone-deep": "^4.0.1",
         "@types/jest": "^26.0.13",
-        "@types/lodash.debounce": "^4.0.6",
-        "@types/lodash.throttle": "^4.1.6",
         "@types/requestidlecallback": "^0.3.1",
         "documentation": "^13.0.2",
         "eslint": "^7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,6 +2659,11 @@
     jest-diff "^25.2.1"
     pretty-format "^25.2.1"
 
+"@types/js-cookie@^2.2.6":
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/@types/js-cookie/-/js-cookie-2.2.6.tgz#f1a1cb35aff47bc5cfb05cb0c441ca91e914c26f"
+  integrity sha512-+oY0FDTO2GYKEV0YPvSshGq9t7YozVkgvXLty7zogQNuCxBhT9/3INX9Q7H1aRZ4SUDRXAKlJuA4EA5nTt7SNw==
+
 "@types/json-schema@^7.0.3":
   version "7.0.5"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
@@ -7353,6 +7358,11 @@ jetifier@^1.6.2:
   version "1.6.6"
   resolved "https://registry.yarnpkg.com/jetifier/-/jetifier-1.6.6.tgz#fec8bff76121444c12dc38d2dad6767c421dab68"
   integrity sha512-JNAkmPeB/GS2tCRqUzRPsTOHpGDah7xP18vGJfIjZC+W2sxEHbxgJxetIjIqhjQ3yYbYNEELkM/spKLtwoOSUQ==
+
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Summary

Prepare `us-web-util` v1.1.0:
- Fix bug where TypeScript types weren't included for re-exported packages.
- Re-export `js-cookie` `Cookies` helper as blessed solution after our internal testing.

## PR Dependencies

None

# How to test

N/A

# Screenshots (may need to be uploaded by tester)

N/A