### PR TITLE
Version v1.0.1 of us-web-config

### DIFF
--- a/packages/us-web-config/CHANGELOG.md
+++ b/packages/us-web-config/CHANGELOG.md
@@ -1,0 +1,8 @@
+# 1.0.1
+
+- Fix issues where TypeScript enums could be a false positive for `no-shadow`.
+- Fix more Vue rules that clash with Prettier.
+
+# 1.0.0
+
+- Initial release.

--- a/packages/us-web-config/eslint/typescript.js
+++ b/packages/us-web-config/eslint/typescript.js
@@ -21,6 +21,8 @@ module.exports = {
         ignoreRestSiblings: true,
       },
     ],
+    "no-shadow": "off",
+    "@typescript-eslint/no-shadow": "warn",
 
     "@typescript-eslint/consistent-type-assertions": "warn",
     "@typescript-eslint/array-type": "warn",

--- a/packages/us-web-config/eslint/vue.js
+++ b/packages/us-web-config/eslint/vue.js
@@ -3,5 +3,11 @@ module.exports = {
     plugins: ['vue'],
     rules: {
         'vue/html-indent': 'off',
+        'vue/max-attributes-per-line': 'off',
+        'vue/html-closing-bracket-newline': 'off',
+        'vue/singleline-html-element-content-newline': 'off',
+        'vue/html-self-closing': 'off',
+        'vue/multiline-html-element-content-newline': 'off',
+        'vue/no-unused-vars': 'off',
     },
 }

--- a/packages/us-web-config/package.json
+++ b/packages/us-web-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dji-dev/us-web-config",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "license": "MIT",
   "contributors": ["Michael Bullington <michael.bullington@dji.com>"],


### PR DESCRIPTION
# Summary

- Replace ESLint `no-shadow` with TypeScript so enums don't give a false positive.
- Disable Vue rules that conflict with Prettier.

## PR Dependencies

https://github.com/dji-dev/us-web/pull/5